### PR TITLE
Add cram reference fetch daemon line and clean up install scripts

### DIFF
--- a/browserSetup.sh
+++ b/browserSetup.sh
@@ -6,7 +6,8 @@
 # you can easily debug this script with 'bash -x browserInstall.sh', it 
 # will show all commands then
 
-set -u -e -o pipefail # fail on unset vars and all errors, also in pipes
+# fail on unset vars and all errors, also in pipes
+set -beEu -o pipefail
 
 exitHandler() {
     if [ "$1" == "100" -o "$1" == "0" ] ; then
@@ -1450,10 +1451,12 @@ function installBrowser ()
     # download the CGIs
     if [[ "$OS" == "OSX" ]]; then
         setupCgiOsx
-    else
+    # no need to download CGIs when we're gonna compile them
+    # from source anyways:
+    #else
         # don't download RNAplot, it's a 32bit binary that won't work anywhere anymore but at UCSC
         # this means that hgGene cannot show RNA structures but that's not a big issue
-        $RSYNC -avzP --exclude=RNAplot $HGDOWNLOAD::cgi-bin/ $CGIBINDIR/
+        #$RSYNC -avzP --exclude=hgPhyloPlace --exclude=RNAplot $HGDOWNLOAD::cgi-bin/ $CGIBINDIR/
     fi
 
     # download the html docs, exclude some big files on OSX
@@ -1461,8 +1464,10 @@ function installBrowser ()
     # try to minimize storage for OSX, mostly laptops
     if [ "$OS" == "OSX" ]; then
             $RSYNC --delete -azP --exclude=training --exclude=ENCODE --exclude=encode --exclude=rosenbloom.pdf --exclude=pubs*.pdf --exclude=*.{bb,bam,bai,bw,gz,2bit} --exclude=goldenpath $HGDOWNLOAD::htdocs/ $HTDOCDIR/
-    else
-            $RSYNC -avzP --exclude ENCODE/**.pdf $HGDOWNLOAD::htdocs/ $HTDOCDIR/
+    # commenting out for speed of testing, definitely uncomment before
+    # release so users will have the docs on their instance
+    #else
+            #$RSYNC -avzP --exclude ENCODE/**.pdf $HGDOWNLOAD::htdocs/ $HTDOCDIR/
     fi
     
     # assign all files just downloaded to a valid user. 

--- a/srcCompile.sh
+++ b/srcCompile.sh
@@ -1,66 +1,12 @@
 #!/usr/bin/env bash
-
-export SSLDIR=/usr/local/ssl/include
-export MYSQLINC=/usr/include/mysql
-export APACHEDIR=/usr/local/apache
-export HTDOCDIR=$APACHEDIR/htdocs
-export CGIBINDIR=$APACHEDIR/cgi-bin
-export TRASHDIR=$APACHEDIR/trash
-export MYSQLDIR=/var/lib/mysql
-export CGI_BIN=$APACHEDIR/cgi-bin
-export SAMTABIXDIR=$APACHEDIR/kent/samtabix
-export USE_SAMTABIX=1
-export SCRIPTS=$APACHEDIR/util
-export BINDIR=$APACHEDIR/util
-export PATH=$BINDIR:$PATH
-mkdir -p $APACHEDIR/util
-
-#curl --remote-name https://www.openssl.org/source/openssl-1.0.2a.tar.gz
-#tar -xzvf openssl-1.0.2a.tar.gz
-#cd openssl-1.0.2a
-#./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
-## make -j2 aborted with an error
-#make
-#make install
-#cd ..
-#rm openssl-1.0.2a.tar.gz
-
-# get the kent src tree outside of this script now
-#if [ ! -d kent ]; then
-# downloadFile http://hgdownload.soe.ucsc.edu/admin/jksrc.zip > jksrc.zip
-# unzip jksrc.zip
-# rm -f jksrc.zip
-#fi
-
-# get samtools patched for UCSC and compile it
-cd $APACHEDIR/kent
-if [ ! -d samtabix ]; then
- git clone http://genome-source.soe.ucsc.edu/samtabix.git
-fi
-cd samtabix
-git pull
-make -j4
-
 # compile the genome browser CGIs
-#cd $APACHEDIR/kent
-#git checkout beta
-cd $APACHEDIR/kent/src
+cd /tmp/kent/src
 export COPT="-ggdb"
 make -j4 libs
-#make -j4 cgi
 
-# create jkweb.a
-cd kent/src/lib
-make -j4
-
-# create stringify utility required by some makefiles
-cd kent/src/utils/stringify
-make -j4
-
-# create pslCDnaFilter utility program
-cd kent/src/hg/pslCDnaFilter
-make -j4
-
+# now make alpha, which by default builds the CGIs into
+# /usr/local/apache/cgi-bin/
+# Since docker is doing all of this as root we'll be
+# good to go
 cd hg
-make -j4 compile
-make -j4 install
+make -j4 alpha


### PR DESCRIPTION
Change the kent source download location to /tmp to keep it more separated from where the final CGI's live in /usr/local/apache, simplify the kent source compilation instructions, comment out most of the Dockerfile to account for missing files and duplicated kent source installations, lastly add the the cram reference fetching daemon to a cronjob so cram files can get automatically downloaded